### PR TITLE
Allow zerofilled numbers with leading zero

### DIFF
--- a/lib/banktools-se/account.rb
+++ b/lib/banktools-se/account.rb
@@ -99,7 +99,7 @@ module BankTools
 
       def serial_number
         number = digits.slice(clearing_number_length..-1) || ""
-        zerofill? ? "%.#{bank_data[:serial_number_length]}d" % number : number
+        zerofill? ? "%.#{bank_data[:serial_number_length]}d" % number.to_i(10) : number
       end
 
       private

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -151,6 +151,9 @@ describe BankTools::SE::Account do
       BankTools::SE::Account.new("12").serial_number.should == ""
     end
 
+    it "should manage pre-zerofilled account numbers" do
+      BankTools::SE::Account.new("8000-2-0800000002").should be_valid
+    end
   end
 
   describe "#normalize" do


### PR DESCRIPTION
Ruby by default treats numbers with a leading zero as being octal numbers.
This makes sure that the number conversion in `Account#serial_number` is
done with `to_i(10)`, to avoid such problems.
