### PR TITLE
Add Account#normalize keyword arguments digits_only, clearing_checksum

### DIFF
--- a/lib/banktools-se/account.rb
+++ b/lib/banktools-se/account.rb
@@ -44,6 +44,14 @@ module BankTools
         end
       end
 
+      def normalize_for_apis
+        if valid?
+          [ digits[0, 4], serial_number ].join("")
+        else
+          number
+        end
+      end
+
       def bank
         bank_data[:name]
       end

--- a/lib/banktools-se/account.rb
+++ b/lib/banktools-se/account.rb
@@ -36,17 +36,16 @@ module BankTools
         errors
       end
 
-      def normalize
+      def normalize(digits_only: false, clearing_checksum: true)
         if valid?
-          [ clearing_number, serial_number ].join("-")
-        else
-          number
-        end
-      end
-
-      def normalize_for_apis
-        if valid?
-          [ digits[0, 4], serial_number ].join("")
+          clearing_number_part =
+            if clearing_checksum
+              clearing_number
+            else
+              digits[0, 4]
+            end
+          result = [ clearing_number_part, serial_number ].join("-")
+          digits_only ? result.gsub(/\D/, "") : result
         else
           number
         end

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -161,24 +161,43 @@ RSpec.describe BankTools::SE::Account do
       expect(BankTools::SE::Account.new("8000-2-80000003").normalize).to   eq("8000-2-0080000003")
       expect(BankTools::SE::Account.new("8000-2-8000000003").normalize).to eq("8000-2-8000000003")
     end
-  end
 
-  describe "#normalize_for_apis" do
-    it "normalizes to clearing number then serial number" do
-      expect(BankTools::SE::Account.new("1100 0000007").normalize_for_apis).to eq("11000000007")
+    context "using digits_only: true" do
+      it "normalizes to clearing number then serial number" do
+        expect(BankTools::SE::Account.new("11000000007").normalize(digits_only: true)).to eq("11000000007")
+      end
+
+      it "keeps any Swedbank/Sparbanker clearing checksum" do
+        expect(BankTools::SE::Account.new("8000-2-0000000000").normalize(digits_only: true)).to eq("800020000000000")
+      end
+
+      it "does not attempt to normalize invalid numbers" do
+        expect(BankTools::SE::Account.new(" 1-2-3 ").normalize(digits_only: true)).to eq(" 1-2-3 ")
+      end
+
+      it "prepends zeroes to the serial number if necessary" do
+        expect(BankTools::SE::Account.new("8000-2-80000003").normalize(digits_only: true)).to   eq("800020080000003")
+        expect(BankTools::SE::Account.new("8000-2-8000000003").normalize(digits_only: true)).to eq("800028000000003")
+      end
     end
 
-    it "drops any Swedbank/Sparbanker clearing checksum" do
-      expect(BankTools::SE::Account.new("8000-2-0000000000").normalize_for_apis).to eq("80000000000000")
-    end
+    context "using clearing_checksum: false" do
+      it "normalizes to clearing number then serial number" do
+        expect(BankTools::SE::Account.new("1100 0000007").normalize(clearing_checksum: false)).to eq("1100-0000007")
+      end
 
-    it "keeps any invalid numbers" do
-      expect(BankTools::SE::Account.new(" 1-2-3 ").normalize_for_apis).to eq(" 1-2-3 ")
-    end
+      it "drops any Swedbank/Sparbanker clearing checksum" do
+        expect(BankTools::SE::Account.new("8000-2-0000000000").normalize(clearing_checksum: false)).to eq("8000-0000000000")
+      end
 
-    it "prepends zeroes to the serial number if necessary" do
-      expect(BankTools::SE::Account.new("8000-2-80000003").normalize_for_apis).to   eq("80000080000003")
-      expect(BankTools::SE::Account.new("8000-2-8000000003").normalize_for_apis).to eq("80008000000003")
+      it "keeps any invalid numbers" do
+        expect(BankTools::SE::Account.new(" 1-2-3 ").normalize(clearing_checksum: false)).to eq(" 1-2-3 ")
+      end
+
+      it "prepends zeroes to the serial number if necessary" do
+        expect(BankTools::SE::Account.new("8000-2-80000003").normalize(clearing_checksum: false)).to   eq("8000-0080000003")
+        expect(BankTools::SE::Account.new("8000-2-8000000003").normalize(clearing_checksum: false)).to eq("8000-8000000003")
+      end
     end
   end
 end

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -162,4 +162,23 @@ RSpec.describe BankTools::SE::Account do
       expect(BankTools::SE::Account.new("8000-2-8000000003").normalize).to eq("8000-2-8000000003")
     end
   end
+
+  describe "#normalize_for_apis" do
+    it "normalizes to clearing number then serial number" do
+      expect(BankTools::SE::Account.new("1100 0000007").normalize_for_apis).to eq("11000000007")
+    end
+
+    it "drops any Swedbank/Sparbanker clearing checksum" do
+      expect(BankTools::SE::Account.new("8000-2-0000000000").normalize_for_apis).to eq("80000000000000")
+    end
+
+    it "keeps any invalid numbers" do
+      expect(BankTools::SE::Account.new(" 1-2-3 ").normalize_for_apis).to eq(" 1-2-3 ")
+    end
+
+    it "prepends zeroes to the serial number if necessary" do
+      expect(BankTools::SE::Account.new("8000-2-80000003").normalize_for_apis).to   eq("80000080000003")
+      expect(BankTools::SE::Account.new("8000-2-8000000003").normalize_for_apis).to eq("80008000000003")
+    end
+  end
 end


### PR DESCRIPTION
This PR fixes #10 by implementing a new public method which offers this functionality.

Example of how an API expresses their needs:

> A Swedish bank account number always comprises a clearing number (four digits) and an account number. The number of digits in an account number varies from bank to bank. When transferring funds to another bank, you must always state the clearing number, followed by the account number, without extra characters like a hyphen, full stop or a space.
An account number in, for example, Handelsbanken, is given as follows: 6789123456789, where 6789 is the clearing number and 123456789 is the account number.

[Source](https://www.danskebank.com/en-uk/BusinessOnline-content/text-pages/RegionalFrontPages/Pages/Bankernaskontonummer.aspx)