### PR TITLE
Drop tests to clarify behaviour

### DIFF
--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -174,21 +174,8 @@ RSpec.describe BankTools::SE::Account do
     end
 
     context "using clearing_checksum: false" do
-      it "normalizes to clearing number then serial number" do
-        expect(BankTools::SE::Account.new("1100 0000007").normalize(clearing_checksum: false)).to eq("1100-0000007")
-      end
-
-      it "drops any Swedbank/Sparbanker clearing checksum" do
+      it "drops any Swedbank/Sparbanker clearing checksum (fifth digit and hyphen)" do
         expect(BankTools::SE::Account.new("8000-2-0000000000").normalize(clearing_checksum: false)).to eq("8000-0000000000")
-      end
-
-      it "keeps any invalid numbers" do
-        expect(BankTools::SE::Account.new(" 1-2-3 ").normalize(clearing_checksum: false)).to eq(" 1-2-3 ")
-      end
-
-      it "prepends zeroes to the serial number if necessary" do
-        expect(BankTools::SE::Account.new("8000-2-80000003").normalize(clearing_checksum: false)).to   eq("8000-0080000003")
-        expect(BankTools::SE::Account.new("8000-2-8000000003").normalize(clearing_checksum: false)).to eq("8000-8000000003")
       end
     end
   end

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -163,21 +163,13 @@ RSpec.describe BankTools::SE::Account do
     end
 
     context "using digits_only: true" do
-      it "normalizes to clearing number then serial number" do
+      it "normalizes without any non-digit separators" do
+        expect(BankTools::SE::Account.new("1100-0000007").normalize(digits_only: true)).to eq("11000000007")
         expect(BankTools::SE::Account.new("11000000007").normalize(digits_only: true)).to eq("11000000007")
-      end
-
-      it "keeps any Swedbank/Sparbanker clearing checksum" do
-        expect(BankTools::SE::Account.new("8000-2-0000000000").normalize(digits_only: true)).to eq("800020000000000")
       end
 
       it "does not attempt to normalize invalid numbers" do
         expect(BankTools::SE::Account.new(" 1-2-3 ").normalize(digits_only: true)).to eq(" 1-2-3 ")
-      end
-
-      it "prepends zeroes to the serial number if necessary" do
-        expect(BankTools::SE::Account.new("8000-2-80000003").normalize(digits_only: true)).to   eq("800020080000003")
-        expect(BankTools::SE::Account.new("8000-2-8000000003").normalize(digits_only: true)).to eq("800028000000003")
       end
     end
 


### PR DESCRIPTION
Some tests were duplicating previous tests, so this PR drops a few of them.