### PR TITLE
CI: Read the Ruby versions from a centralized location

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,19 @@ on:
     branches: [ master ]
 
 jobs:
-  test:
+  ruby-versions:
+    uses: ruby/actions/.github/workflows/ruby_versions.yml@master
+    with:
+      min_version: 3.1
+      engine: cruby
 
+  test:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        ruby-version:
-          - 3.3
-          - 3.2
-          - 3.1
-          - "3.0"
+        needs: ruby-versions
+        ruby-version: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
...instead of manually maintaining a list.

When something becomes EOL, we up the min_version.

Inspired by the ruby/rake and other "standard library gems" CI setups.